### PR TITLE
Correct score selection in FcFontSetMatchInternal, and some debug utils

### DIFF
--- a/src/fcbitset.c
+++ b/src/fcbitset.c
@@ -8,12 +8,6 @@
 #include "fcint.h"
 #include <stdlib.h>
 
-struct _FcBitset {
-    size_t size;
-    size_t ones;
-    FcChar8 data[];
-};
-
 FcBitset *
 FcBitsetCreate (size_t size)
 {

--- a/src/fcdbg.c
+++ b/src/fcdbg.c
@@ -559,6 +559,18 @@ FcFontSetPrint (const FcFontSet *s)
     }
 }
 
+void
+FcBitsetPrint (const FcBitset *s)
+{
+    int 	i;
+    printf ("Bitset of size %d (%d ones): ", s->size, s->ones);
+    for (i = 0; i < (s->size + 7) / 8; i++)
+    {
+	printf ("%02x ", s->data[i]);
+    }
+    printf ("\n");
+}
+
 int FcDebugVal;
 
 void

--- a/src/fcint.h
+++ b/src/fcint.h
@@ -600,7 +600,11 @@ struct _FcValuePromotionBuffer {
 
 /* fcbitset.c */
 
-typedef struct _FcBitset FcBitset;
+typedef struct _FcBitset {
+    size_t size;
+    size_t ones;
+    FcChar8 data[];
+} FcBitset;
 
 FcPrivate FcBitset *
 FcBitsetCreate (size_t size);
@@ -864,6 +868,9 @@ FcCharSetPrint (const FcCharSet *c);
 
 FcPrivate void
 FcPatternPrint2 (FcPattern *p1, FcPattern *p2, const FcObjectSet *os);
+
+FcPrivate void
+FcBitsetPrint (const FcBitset *s);
 
 extern FcPrivate int FcDebugVal;
 

--- a/src/fcmatch.c
+++ b/src/fcmatch.c
@@ -695,6 +695,9 @@ FcFontSetMatchInternal (FcFontSet   **sets,
 			FcResult    *result)
 {
     FcPattern *best = NULL;
+    int set;
+    int index;
+    int f;
 
     if (FcDebug () & FC_DBG_MATCH)
     {
@@ -702,12 +705,22 @@ FcFontSetMatchInternal (FcFontSet   **sets,
 	FcPatternPrint (p);
     }
 
+    if (FcDebug () & FC_DBG_MATCHV)
+    {
+	index = 0;
+	for (set = 0; set < nsets; set++)
+	    for (f = 0; f < sets[set]->nfont; f++, index++)
+	    {
+		printf ("Font %d ", index);
+		FcPatternPrint (sets[set]->fonts[f]);
+	    }
+    }
+
     // Preprocess pattern
     FcPreprocessPattern(p);
 
     // Count fonts in all sets
     size_t font_count = 0;
-    int set;
     for (set = 0; set < nsets; set++)
 	font_count += sets[set]->nfont;
 
@@ -735,6 +748,9 @@ FcFontSetMatchInternal (FcFontSet   **sets,
     int priority;
     for (priority = 0; priority < PRI_END; priority++)
     {
+	if (FcDebug () & FC_DBG_MATCHV)
+	    printf ("Priority %d:\n", priority);
+
 	// Find the matcher for given priority
 	const FcMatcher *matcher = NULL;
 	for (matcher = &_FcMatchers[0]; matcher->weak != priority && matcher->strong != priority; matcher++);
@@ -750,9 +766,7 @@ FcFontSetMatchInternal (FcFontSet   **sets,
 	double best_score_so_far = 1e99;
 
 	// Iterate over all fonts in all sets
-	int index = 0;
-	int set;
-	for (set = 0; set < nsets; set++)
+	for (set = 0, index = 0; set < nsets; set++)
 	{
 	    FcFontSet *s = sets[set];
 	    if (!s)
@@ -803,6 +817,13 @@ FcFontSetMatchInternal (FcFontSet   **sets,
 	    }
 	}
 
+	if (FcDebug () & FC_DBG_MATCHV)
+	{
+	    printf ("Best ");
+	    FcBitsetPrint (best_matches_so_far);
+	}
+
+
 	// If we managed to narrow the search down to one font, it is stored in `best` variable, go out.
 	if (FcBitsetCountOnes(best_matches_so_far) <= 1)
 	    break;
@@ -812,6 +833,12 @@ FcFontSetMatchInternal (FcFontSet   **sets,
 	FcBitset *tmp = best_matches_so_far;
 	best_matches_so_far = possible_matches;
 	possible_matches = tmp;
+    }
+
+    if (FcDebug () & FC_DBG_MATCH)
+    {
+	printf ("Best ");
+	FcPatternPrint (best);
     }
 
     /* assuming that 'result' is initialized with FcResultNoMatch


### PR DESCRIPTION
FcFontSetMatchInternal was using the strength of the first element in
deciding which score to use. This is wrong as we should look at the
priority instead.

Instead of building two scores to choose from, we now only use one
score variable and decide whether it should be used for strong, weak,
or both by testing for matcher->{strong,weak} == priority. Doing so
ensures perfect emulation of FcCompare() behavior for each priority.

Fixes #2.